### PR TITLE
Add pyproject.toml, to make it easier to run with `uv` directly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+*.py[cod]
+__pycache__
+.env

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ curl -LsSf https://astral.sh/uv/install.sh | sh
 NOCODB_EMAIL="your@email.com" \
 NOCODB_PASSWORD="yourpassword" \
 BASE_ID="p2b1mor87640vjw" \
-uv run --with requests nocodb_full_export.py
+uv run nocodb_full_export.py
 ```
 
 ### Import a Base
@@ -23,7 +23,7 @@ uv run --with requests nocodb_full_export.py
 NOCODB_EMAIL="your@email.com" \
 NOCODB_PASSWORD="yourpassword" \
 IMPORT_FILE="nocodb_export_BaseName_TIMESTAMP.json" \
-uv run --with requests nocodb_full_import.py
+uv run nocodb_full_import.py
 ```
 
 ## Authentication
@@ -109,7 +109,7 @@ NOCODB_PASSWORD=yourpassword
 BASE_ID=p123abc
 EOF
 
-export $(cat .env | xargs) && uv run --with requests nocodb_full_export.py
+uv run nocodb_full_export.py
 ```
 
 **Batch export:**

--- a/nocodb_full_export.py
+++ b/nocodb_full_export.py
@@ -16,7 +16,7 @@ import json
 from datetime import datetime
 from typing import Dict, List
 
-from nocodb_utils import make_request, get_config_with_auth, check_requests_library
+from nocodb_utils import make_request, get_config_with_auth
 
 
 def export_base_metadata(base_id: str, token: str, url: str) -> Dict:
@@ -203,5 +203,4 @@ def main():
 
 
 if __name__ == '__main__':
-    check_requests_library()
     main()

--- a/nocodb_full_import.py
+++ b/nocodb_full_import.py
@@ -16,7 +16,7 @@ import json
 import time
 from typing import Dict, List
 
-from nocodb_utils import make_request, get_config_with_auth, check_requests_library
+from nocodb_utils import make_request, get_config_with_auth
 
 
 def create_base(title: str, description: str, token: str, url: str, workspace_id: str = None) -> Dict:
@@ -254,5 +254,4 @@ def main():
 
 
 if __name__ == '__main__':
-    check_requests_library()
     main()

--- a/nocodb_utils.py
+++ b/nocodb_utils.py
@@ -9,21 +9,12 @@ Shared functions for NocoDB export/import scripts including:
 - Configuration management
 """
 
+import dotenv
 import os
 import sys
 import requests
 from typing import Dict, Optional
 
-
-def check_requests_library():
-    """Check if requests library is installed"""
-    try:
-        import requests
-    except ImportError:
-        print('❌ Error: requests library not found')
-        print('\nPlease install it with:')
-        print('  pip install requests')
-        sys.exit(1)
 
 
 def make_request(url: str, method: str = 'GET', token: str = '',
@@ -108,6 +99,7 @@ def get_config_with_auth(required_vars: list, optional_vars: dict = None) -> Dic
     Returns:
         Configuration dictionary
     """
+    dotenv.load_dotenv()
     optional_vars = optional_vars or {}
 
     # Base configuration

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,10 @@
+[project]
+name = "nocodb-export"
+version = "0.1.0"
+description = "Add your description here"
+readme = "README.md"
+requires-python = ">=3.12"
+dependencies = [
+    "python-dotenv>=1.2.1",
+    "requests>=2.32.5",
+]


### PR DESCRIPTION
- This allows removing the "check_requests_library" function, since the dependencies are now encoded in pyproject
- also added a .gitignore file, and automatic loading of .env file